### PR TITLE
Support horizontal pod autoscaler

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -96,8 +96,9 @@ func isCompleted(status corev1.PodStatus) bool {
 func (c *Controller) handleWorker(ctx context.Context, scheduler *corev1.Service, cluster *daskv1alpha1.Cluster) error {
 	fieldManager := "dask-operator-worker"
 	name := fmt.Sprintf("%s-worker", cluster.Name)
+	workerLabels := labels.SelectorFromSet(clusterLabels(cluster, "worker"))
 
-	pods, err := c.pods.Lister().Pods(cluster.Namespace).List(labels.SelectorFromSet(clusterLabels(cluster, "worker")))
+	pods, err := c.pods.Lister().Pods(cluster.Namespace).List(workerLabels)
 	if err != nil {
 		return err
 	}
@@ -119,7 +120,10 @@ func (c *Controller) handleWorker(ctx context.Context, scheduler *corev1.Service
 		return err
 	}
 
-	status := daskv1alpha1ac.WorkerStatus().WithReplicas(int32(len(pods)))
+	status := daskv1alpha1ac.WorkerStatus().
+		WithSelector(workerLabels.String()).
+		WithReplicas(int32(len(pods)))
+
 	for _, retiringPod := range cluster.Status.Workers.Retiring {
 		if _, ok := podIds[retiringPod.Id]; ok {
 			klog.V(1).Infof("waiting for pod %s to retire in cluster %s/%s", retiringPod.Id, cluster.Namespace, cluster.Name)

--- a/pkg/apis/dask/v1alpha1/types.go
+++ b/pkg/apis/dask/v1alpha1/types.go
@@ -32,6 +32,8 @@ type RetiredWorker struct {
 
 type WorkerStatus struct {
 	Replicas int32 `json:"count"`
+	// To support the horizontal pod autoscaler
+	Selector string `json:"selector,omitEmpty"`
 	// +listType=map
 	// +listMapKey=id
 	Retiring []RetiredWorker `json:"retiring,omitempty"`
@@ -44,7 +46,7 @@ type ClusterStatus struct {
 
 // +genclient
 // +kubebuilder:subresource:status
-// +kubebuilder:subresource:scale:specpath=.spec.workers.replicas,statuspath=.status.workers.count
+// +kubebuilder:subresource:scale:specpath=.spec.workers.replicas,statuspath=.status.workers.count,selectorpath=.status.workers.selector
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type Cluster struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
Instead of implementing our own autoscaling logic, we can use the [horizontal pod autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) to manage replicas and scaling. That way, we can use the back-off, rate-limiting, etc logic already implemented here.

The only limitation is that it does not support scaling to 0 replicas, only 1 (though this can be enabled by toggling an alpha feature-flag).

The horizontal pod autoscaler needs to be able to find the pods that belong to a workload. This is done by exposing the label-selector as a string property.

# Testing

- [x] Create a Dask cluster in a sandbox environment
  - [x] Expose the desired workers metric as an autoscaling target
  - [x] Attach a horizontal pod autoscaler to it