### PR TITLE
Support horizontal pod autoscaler

### DIFF
--- a/pkg/apis/dask/v1alpha1/types.go
+++ b/pkg/apis/dask/v1alpha1/types.go
@@ -32,6 +32,8 @@ type RetiredWorker struct {
 
 type WorkerStatus struct {
 	Replicas int32 `json:"count"`
+	// To support the horizontal pod autoscaler
+	Selector string `json:"selector,omitEmpty"`
 	// +listType=map
 	// +listMapKey=id
 	Retiring []RetiredWorker `json:"retiring,omitempty"`
@@ -44,7 +46,7 @@ type ClusterStatus struct {
 
 // +genclient
 // +kubebuilder:subresource:status
-// +kubebuilder:subresource:scale:specpath=.spec.workers.replicas,statuspath=.status.workers.count
+// +kubebuilder:subresource:scale:specpath=.spec.workers.replicas,statuspath=.status.workers.count,selectorpath=.status.workers.selector
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type Cluster struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
**Duplicate of #3, which was merged into the wrong branch**

Instead of implementing our own autoscaling logic, we can use the [horizontal pod autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) to manage replicas and scaling. That way, we can use the back-off, rate-limiting, etc logic already implemented here.

The only limitation is that it does not support scaling to 0 replicas, only 1 (though this can be enabled by toggling an alpha feature-flag).

The horizontal pod autoscaler needs to be able to find the pods that belong to a workload. This is done by exposing the label-selector as a string property.

# Testing

- [x] Create a Dask cluster in a sandbox environment
  - [x] Expose the desired workers metric as an autoscaling target
  - [x] Attach a horizontal pod autoscaler to it